### PR TITLE
Accept second argument as command

### DIFF
--- a/kubexec
+++ b/kubexec
@@ -1,4 +1,4 @@
 #!/bin/bash
 POD_NAME=`(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}') | grep $1`
-cmd="${2:-bash}"
-kubectl exec -it $POD_NAME -- $cmd
+CMD="${2:-bash}"
+kubectl exec -it $POD_NAME -- $CMD

--- a/kubexec
+++ b/kubexec
@@ -1,3 +1,4 @@
 #!/bin/bash
 POD_NAME=`(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}') | grep $1`
-kubectl exec -it $POD_NAME -- bash
+cmd="${2:-bash}"
+kubectl exec -it $POD_NAME -- $cmd


### PR DESCRIPTION
Added a feature to accept a second argument that will be the command being executed in the pods. This is because bash does not exist in all pods/containers. If the second argument is not specified then it will be defaulted to bash.